### PR TITLE
Translating "now" keyword to a valid timestamp

### DIFF
--- a/git-redate
+++ b/git-redate
@@ -54,6 +54,11 @@ ${VISUAL:-${EDITOR:-vi}} $tmpfile
 ENVFILTER=""
 while read commit; do
     IFS="|" read date hash message <<< "$commit"
+    shopt -s nocasematch
+    if [[ "$date" == 'now' ]]; then
+        date=$(date +%Y-%m-%dT%H:%M:%S%z);
+    fi
+    shopt -u nocasematch
     if [ "$datefmt" == "%cI" ]
     then
         DATE_NO_SPACE="$(echo "${date}" | tr -d '[[:space:]]')"


### PR DESCRIPTION
I'd like to be able to use the word "now" when editing commits. This change enables that, pending your approvals/corrections :)