### PR TITLE
Use the standard environment variable EDITOR instead of asking the user

### DIFF
--- a/git-redate
+++ b/git-redate
@@ -27,6 +27,9 @@ is_has_editor() {
     if [ -f "$SETTINGS_FILE" ]
     then
         OUR_EDITOR=$(cat ${SETTINGS_FILE});
+    elif [ ! -z "$EDITOR" ]
+    then
+	OUR_EDITOR="$EDITOR";
     else
         make_editor_choice;
         if [ ${CHOOSE_EDITOR} == 1 ] || [ ${CHOOSE_EDITOR} == "1" ];


### PR DESCRIPTION
Before asking the user for the editor to choose, checks the $EDITOR environment variable.
Note : one could also use the GIT_EDITOR variable or git core.editor