### PR TITLE
fix(git-redate): fix settings path

### DIFF
--- a/git-redate
+++ b/git-redate
@@ -30,8 +30,8 @@ get_editor_executable() {
 
 
 is_has_editor() {
-    SETTINGS_FILE="~/.redate-settings";
-    if [ -f "$SETTINGS_FILE" ]
+    SETTINGS_FILE="$HOME/.redate-settings";
+    if [ -f $SETTINGS_FILE ]
     then
         OUR_EDITOR=$(cat ${SETTINGS_FILE});
     elif [ ! -z "$EDITOR" ]


### PR DESCRIPTION
I noticed that in my pc (Ubuntu 20 - bash), using `SETTINGS_FILE="~/.redate-settings";` does not work when tested with `[ -f $SETTINGS_FILE ]`, while `SETTINGS_FILE="$HOME/.redate-settings"` does