### PR TITLE
Remove unnecessary "\n" at the end of some echo statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Change the dates of several git commits with a single command.
 
-![alt tag](http://oi68.tinypic.com/3ud82.jpg)
+![alt tag](https://i.stack.imgur.com/yE4cQ.gif)
 
 # Installation
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ For homebrew users, you need to run `brew tap PotatoLabs/homebrew-git-redate` an
 
 If you're not using homebrew, you can clone this repo and move the `git-redate` file into any folders in your $PATH. Restart your terminal afterwards and you're good to go!
 
+For window's users, you may paste the file into `${INSTALLATION_PATH}\mingw64\libexec\git-core`. Assuming you used the default settings the installation path will be `C:\Program Files\Git`.
+
 # Usage
 
 Simply run: `git redate --commits [[number of commits to view]]`.  You'll have to force push in order for your commit history to be rewritten.

--- a/git-redate
+++ b/git-redate
@@ -77,14 +77,16 @@ while read commit; do
     else
         DATE_NO_SPACE="$(echo "${date}")"
     fi
+
+
     COMMIT_ENV=$(cat <<-END
-        if [ \$GIT_COMMIT = $hash ];
-        then
-            export GIT_AUTHOR_DATE="$DATE_NO_SPACE"
-            export GIT_COMMITTER_DATE="$DATE_NO_SPACE";
-        fi;
-	END
-    )
+if [ \$GIT_COMMIT = $hash ];
+then
+    export GIT_AUTHOR_DATE="$DATE_NO_SPACE"
+    export GIT_COMMITTER_DATE="$DATE_NO_SPACE";
+fi;
+END
+)
     ENVFILTER="$ENVFILTER$COMMIT_ENV"
 done < $tmpfile
 

--- a/git-redate
+++ b/git-redate
@@ -16,9 +16,16 @@ make_editor_choice() {
     echo "Which editor do you want to use for this repo?\n";
     echo "1. VI\n";
     echo "2. NANO\n";
+    echo "3. Your own\n"
     echo "You Choose: ";
 
     read CHOOSE_EDITOR
+}
+
+get_editor_executable() {
+
+    echo "What is the path to your prefered test editor?\n";
+    read EDITOR_PATH
 }
 
 
@@ -32,8 +39,10 @@ is_has_editor() {
 	OUR_EDITOR="$EDITOR";
     else
         make_editor_choice;
-        if [ ${CHOOSE_EDITOR} == 1 ] || [ ${CHOOSE_EDITOR} == "1" ];
-        then
+        if [ ${CHOOSE_EDITOR} == 3 ] || [ ${CHOOSE_EDITOR} == "3" ]; then
+            get_editor_executable
+            OUR_EDITOR=${EDITOR_PATH}
+        elif [ ${CHOOSE_EDITOR} == 1 ] || [ ${CHOOSE_EDITOR} == "1" ]; then
             OUR_EDITOR="vi";
         else
             OUR_EDITOR="nano";

--- a/git-redate
+++ b/git-redate
@@ -23,7 +23,7 @@ make_editor_choice() {
 
 
 is_has_editor() {
-    SETTINGS_FILE="redate-settings";
+    SETTINGS_FILE="~/.redate-settings";
     if [ -f "$SETTINGS_FILE" ]
     then
         OUR_EDITOR=$(cat ${SETTINGS_FILE});

--- a/git-redate
+++ b/git-redate
@@ -27,6 +27,9 @@ is_has_editor() {
     if [ -f "$SETTINGS_FILE" ]
     then
         OUR_EDITOR=$(cat ${SETTINGS_FILE});
+    elif [ ! -z "$EDITOR" ]
+    then
+	OUR_EDITOR="$EDITOR";
     else
         make_editor_choice;
         if [ ${CHOOSE_EDITOR} == 1 ] || [ ${CHOOSE_EDITOR} == "1" ];

--- a/git-redate
+++ b/git-redate
@@ -21,6 +21,7 @@ make_editor_choice() {
     read CHOOSE_EDITOR
 }
 
+
 is_has_editor() {
     SETTINGS_FILE="redate-settings";
     if [ -f "$SETTINGS_FILE" ]
@@ -40,7 +41,10 @@ is_has_editor() {
 
 is_has_editor
 
+
 ALL=0
+DEBUG=0
+LIMITCHUNKS=20
 
 while [[ $# -ge 1 ]]
 do
@@ -50,6 +54,15 @@ case $key in
     -c| --commits)
     COMMITS="$2"
     if [ -z "${COMMITS}" ]; then COMMITS="5"; fi;
+    shift
+    ;;
+    -l| --limit)
+    LIMITCHUNKS="$2"
+    if [ -z "${LIMITCHUNKS}" ]; then LIMITCHUNKS="20"; fi;
+    shift
+    ;;
+    -d| --debug)
+    DEBUG=1
     shift
     ;;
     -a| --all)
@@ -84,15 +97,22 @@ then
     git log --pretty=format:"$datefmt | %H | %s" > $tmpfile;
 else
     if [ -n "${COMMITS+set}" ];
-    then git log -n $COMMITS --pretty=format:"$datefmt | %H | %s" > $tmpfile;
+    then git log -n ${COMMITS} --pretty=format:"$datefmt | %H | %s" > $tmpfile;
     else git log -n 5 --pretty=format:"$datefmt | %H | %s" > $tmpfile;
     fi
 fi
 
 ${VISUAL:-${EDITOR:-${OUR_EDITOR}}} $tmpfile
 
-ENVFILTER=""
-while read commit; do
+
+ITER=0
+COLITER=0
+declare -a COLLECTION
+
+COUNTCOMMITS=$(awk 'END {print NR}' $tmpfile)
+
+while read commit || [ -n "$commit" ]; do
+
     IFS="|" read date hash message <<< "$commit"
     shopt -s nocasematch
     if [[ "$date" == 'now' ]]; then
@@ -115,15 +135,60 @@ then
 fi;
 END
 )
-    ENVFILTER="$ENVFILTER$COMMIT_ENV"
+
+    ((ITER++))
+
+    if [ "${DEBUG}" -eq 1 ] && [ $((ITER % LIMITCHUNKS)) == $((LIMITCHUNKS - 1)) ];
+    then
+        echo "Chunk $COLITER Finished"
+    fi
+
+    if [ $((ITER % LIMITCHUNKS)) == 0 ]
+    then
+        ((COLITER++))
+
+        if [ "${DEBUG}" -eq 1 ];
+        then
+            echo "Chunk $COLITER Started"
+        fi
+
+    fi
+
+    COLLECTION[$COLITER]=${COLLECTION[COLITER]}"$COMMIT_ENV"
+    if [ "${DEBUG}" -eq 1 ]
+    then
+        echo "Commit $ITER/$COUNTCOMMITS Collected"
+    fi
+
 done < $tmpfile
 
-if [ "${ALL}" -eq 1 ];
-then
-    git filter-branch -f --env-filter "$ENVFILTER" -- --all >/dev/null
-else
-    git filter-branch -f --env-filter "$ENVFILTER" HEAD~$COMMITS..HEAD >/dev/null
-fi
+ITERATOR=0
+for each in "${COLLECTION[@]}"
+do
+
+    ((ITERATOR++))
+
+    if [ "${ALL}" -eq 1 ];
+    then
+        if [ "${DEBUG}" -eq 1 ];
+        then
+            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Started"
+            git filter-branch -f --env-filter "$each" -- --all
+            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Finished"
+        else
+            git filter-branch -f --env-filter "$each" -- --all >/dev/null
+        fi
+    else
+        if [ "${DEBUG}" -eq 1 ];
+        then
+            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Started"
+            git filter-branch -f --env-filter "$each" HEAD~${COMMITS}..HEAD
+            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Finished"
+        else
+            git filter-branch -f --env-filter "$each" HEAD~${COMMITS}..HEAD >/dev/null
+        fi
+    fi
+done
 
 if [ $? = 0 ] ; then
     echo "Git commit dates updated. Run 'git push -f BRANCH_NAME' to push your changes."

--- a/git-redate
+++ b/git-redate
@@ -11,6 +11,35 @@ is_git_repo() {
 
 is_git_repo
 
+make_editor_choice() {
+
+    echo "Which editor do you want to use for this repo?\n";
+    echo "1. VI\n";
+    echo "2. NANO\n";
+    echo "You Choose: ";
+
+    read CHOOSE_EDITOR
+}
+
+is_has_editor() {
+    SETTINGS_FILE="redate-settings";
+    if [ -f "$SETTINGS_FILE" ]
+    then
+        OUR_EDITOR=$(cat ${SETTINGS_FILE});
+    else
+        make_editor_choice;
+        if [ ${CHOOSE_EDITOR} == 1 ] || [ ${CHOOSE_EDITOR} == "1" ];
+        then
+            OUR_EDITOR="vi";
+        else
+            OUR_EDITOR="nano";
+        fi
+        echo ${OUR_EDITOR} > ${SETTINGS_FILE}
+    fi
+}
+
+is_has_editor
+
 ALL=0
 
 while [[ $# -ge 1 ]]
@@ -60,8 +89,7 @@ else
     fi
 fi
 
-${VISUAL:-${EDITOR:-vi}} $tmpfile
-
+${VISUAL:-${EDITOR:-${OUR_EDITOR}}} $tmpfile
 
 ENVFILTER=""
 while read commit; do

--- a/git-redate
+++ b/git-redate
@@ -13,18 +13,18 @@ is_git_repo
 
 make_editor_choice() {
 
-    echo "Which editor do you want to use for this repo?\n";
-    echo "1. VI\n";
-    echo "2. NANO\n";
-    echo "3. Your own\n"
-    echo "You Choose: ";
+    echo "Which editor do you want to use for this repo?";
+    echo "1. VI";
+    echo "2. NANO";
+    echo "3. Your own"
+    echo -n "You Choose: ";
 
     read CHOOSE_EDITOR
 }
 
 get_editor_executable() {
 
-    echo "What is the path to your prefered test editor?\n";
+    echo "What is the path to your prefered test editor?";
     read EDITOR_PATH
 }
 


### PR DESCRIPTION
### Summary
As you can see in the diff section, this PR simply removes `\n` in echo statements in the `make_editor_choice()` and `get_editor_choice()` functions. This `\n` is literally printed as `\n` and not a new line.
```
Which editor do you want to use for this repo?\n
1. VI\n
2. NANO\n
3. Your own\n
You Choose: 
```
This PR removes that unnecessary `\n`.

#### My bash version
```
GNU bash, version 5.1.4(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```