### PR TITLE
Improve script performance by disabling the warning from git filter-branch

### DIFF
--- a/git-redate
+++ b/git-redate
@@ -174,6 +174,8 @@ END
 
 done < $tmpfile
 
+export FILTER_BRANCH_SQUELCH_WARNING=1
+
 ITERATOR=0
 for each in "${COLLECTION[@]}"
 do


### PR DESCRIPTION
Relates to #32 .

Add `FILTER_BRANCH_SQUELCH_WARNING=1` environment variable export to disable `git filter-branch` warning that affects script performance.

The `goit filter-branch` command warning adds delay for several seconds to each command execution making the `redate` command running quite slow.
```
WARNING: git-filter-branch has a glut of gotchas generating mangled history
	 rewrites.  Hit Ctrl-C before proceeding to abort, then use an
	 alternative filtering tool such as 'git filter-repo'
	 (https://github.com/newren/git-filter-repo/) instead.  See the
	 filter-branch manual page for more details; to squelch this warning,
	 set FILTER_BRANCH_SQUELCH_WARNING=1.
Proceeding with filter-branch...  
```