### PR TITLE
Integrate with core Git subcommand authoring features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The available options are:
 - `redate.debug`: takes a boolean value.  When enabled, `git redate` defaults to issuing extra diagnostic information to standard error.
 - `redate.limit`: takes a positive integer.  Used as the default number of commits to modify in a single `git filter-branch` operation.
 - `redate.original`: takes a namespace.  Used as the namespace where the re-dated commits will be stored.[^git-filter-branch-help]
+- `redate.gpgsign`: takes a boolean value.  When enabled, `git redate` defaults to signing re-dated commits.
 
 Example configuration:
 
@@ -50,6 +51,7 @@ commits = 10
 debug = true
 limit = 35
 original = refs/redate
+gpgsign = yes
 ```
 
 [^git-gitrevisions-help]: See [`git help gitrevisions`](https://git-scm.com/docs/gitrevisions) for various ways to spell commit ranges.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,38 @@ For window's users, you may paste the file into `${INSTALLATION_PATH}\mingw64\li
 
 Simply run: `git redate --commits [[number of commits to view]]`.  You'll have to force push in order for your commit history to be rewritten.
 
-To be able to edit all the commits at once add the --all option: `git redate --all`
+To be able to edit all the commits at once add the --all option: `git redate --all`.  This option can be negated with `--no-all`.
+
+You can also specify a range of commits[^git-gitrevisions-help] as a positional parameter, instead of `--count` or `--all`: `git redate HEAD~10..HEAD~6`
 
 **Make sure to run this on a clean working directory otherwise it won't work.**
 
 The `--commits` (a.k.a. `-c`) argument is optional, and defaults to 5 if not provided.
 
+<!-- note that this renders an info box -->
+> **Note**
+> See `git redate -h` for further usage information.
+
+## Configuration
+
+You may set default values for various `git redate` options in your Git client configuration.[^git-config-help]
+
+The available options are:
+
+- `redate.all`: takes a boolean value (`true`, `false`, `yes`, `no`, etc.[^git-config-help]). When enabled, `git redate` defaults to editing all commits.
+- `redate.commits`: takes a positive integer.  Used as the default number of commits to edit.
+- `redate.debug`: takes a boolean value.  When enabled, `git redate` defaults to issuing extra diagnostic information to standard error.
+- `redate.limit`: takes a positive integer.  Used as the default number of commits to modify in a single `git filter-branch` operation.
+
+Example configuration:
+
+```INI
+[redate]
+all = no
+commits = 10
+debug = true
+limit = 35
+```
+
+[^git-gitrevisions-help]: See [`git help gitrevisions`](https://git-scm.com/docs/gitrevisions) for various ways to spell commit ranges.
+[^git-config-help]: See [`git help config`](https://git-scm.com/docs/git-config) for more info on configuring your Git client.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The available options are:
 - `redate.commits`: takes a positive integer.  Used as the default number of commits to edit.
 - `redate.debug`: takes a boolean value.  When enabled, `git redate` defaults to issuing extra diagnostic information to standard error.
 - `redate.limit`: takes a positive integer.  Used as the default number of commits to modify in a single `git filter-branch` operation.
+- `redate.original`: takes a namespace.  Used as the namespace where the re-dated commits will be stored.[^git-filter-branch-help]
 
 Example configuration:
 
@@ -48,7 +49,9 @@ all = no
 commits = 10
 debug = true
 limit = 35
+original = refs/redate
 ```
 
 [^git-gitrevisions-help]: See [`git help gitrevisions`](https://git-scm.com/docs/gitrevisions) for various ways to spell commit ranges.
 [^git-config-help]: See [`git help config`](https://git-scm.com/docs/git-config) for more info on configuring your Git client.
+[^git-filter-branch-help]: See [`git help filter-branch`](https://git-scm.com/docs/git-filter-branch) for more info on `git filter-branch` options.

--- a/git-redate
+++ b/git-redate
@@ -14,12 +14,12 @@ d,debug             show diagnostic output
 c,commits=<commits> number of commits to re-date (default: 5)
 l,limit=<limit>     number of commits to re-date in a single batch (default: 20)
 a,all               re-date all commits
+n,dry-run           show re-dating commands, but do not execute them
 "
 
 # Allow running this command from a subdirectory of the working tree
 # shellcheck disable=SC1091
 SUBDIRECTORY_OK=yes . "$(git --exec-path)/git-sh-setup"
-
 
 make_editor_choice() {
 
@@ -66,6 +66,7 @@ is_has_editor
 
 ALL=0
 DEBUG=0
+DRY_RUN=0
 LIMITCHUNKS=20
 
 while [ "$#" -ge 1 ]
@@ -94,6 +95,12 @@ case $key in
     ;;
     --no-all)
     ALL=0
+    ;;
+    -n| --dry-run)
+    DRY_RUN=1
+    ;;
+    --no-dry-run)
+    DRY_RUN=0
     ;;
     --)
     shift
@@ -133,6 +140,15 @@ else
     }
 fi
 
+if [ "$DRY_RUN" = 1 ]; then
+    run() {
+        echo "$*" 1>&2
+    }
+else
+    run() {
+        "$@"
+    }
+fi
 
 datefmt=%cI
 if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ];
@@ -220,9 +236,9 @@ do
 
     if [ "${ALL}" -eq 1 ];
     then
-        git filter-branch -f --env-filter "$each" -- --all || rc="$?"
+        run git filter-branch -f --env-filter "$each" -- --all || rc="$?"
     else
-        git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}"..HEAD || rc="$?"
+        run git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}"..HEAD || rc="$?"
     fi
 
     debug "Chunk $ITERATOR/$COLITER Finished"

--- a/git-redate
+++ b/git-redate
@@ -166,6 +166,16 @@ else
     }
 fi
 
+if [ "$ALL" = 1 ]; then
+    apply_redate() {
+        run git filter-branch -f --env-filter "${1?}" -- --all
+    }
+else
+    apply_redate() {
+        run git filter-branch -f --env-filter "${1?}" "HEAD~${COMMITS}..HEAD"
+    }
+fi
+
 datefmt=%cI
 if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ];
 then
@@ -244,12 +254,7 @@ do
 
     debug "Chunk $ITERATOR/$COLITER Started"
 
-    if [ "${ALL}" -eq 1 ];
-    then
-        run git filter-branch -f --env-filter "$each" -- --all || rc="$?"
-    else
-        run git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}"..HEAD || rc="$?"
-    fi
+    apply_redate "$each" || rc="$?"
 
     debug "Chunk $ITERATOR/$COLITER Finished"
 

--- a/git-redate
+++ b/git-redate
@@ -123,6 +123,16 @@ cleanup() {
 
 trap cleanup EXIT
 
+if [ "$DEBUG" = 1 ]; then
+    debug() {
+        echo "$*" 1>&2
+    }
+else
+    debug() {
+        :
+    }
+fi
+
 
 datefmt=%cI
 if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ];
@@ -184,25 +194,18 @@ END
     if [ $((ITER % LIMITCHUNKS)) = 0 ]
     then
         COLITER="$((COLITER+1))"
-
-        if [ "${DEBUG}" -eq 1 ];
-        then
-            echo "Chunk $COLITER Started"
-        fi
+        debug "Chunk $COLITER Started"
     fi
 
     ITER="$((ITER + 1))"
 
     eval "__GIT_REDATE_COLLECTION_${COLITER}=\"\${__GIT_REDATE_COLLECTION_${COLITER}:-}\${COMMIT_ENV}\""
 
-    if [ "${DEBUG}" -eq 1 ]
-    then
-        echo "Commit $ITER/$COUNTCOMMITS Collected"
-    fi
+    debug "Commit $ITER/$COUNTCOMMITS Collected"
 
-    if [ "${DEBUG}" -eq 1 ] && [ $((ITER % LIMITCHUNKS)) = 0 ];
+    if [ $((ITER % LIMITCHUNKS)) = 0 ];
     then
-        echo "Chunk $COLITER Finished"
+        debug "Chunk $COLITER Finished"
     fi
 done < "$tmpfile"
 
@@ -213,26 +216,16 @@ do
     each=""
     eval "each=\"\$__GIT_REDATE_COLLECTION_${ITERATOR}\""
 
+    debug "Chunk $ITERATOR/$COLITER Started"
+
     if [ "${ALL}" -eq 1 ];
     then
-        if [ "${DEBUG}" -eq 1 ];
-        then
-            echo "Chunk $ITERATOR/$COLITER Started"
-            git filter-branch -f --env-filter "$each" -- --all || rc="$?"
-            echo "Chunk $ITERATOR/$COLITER Finished"
-        else
-            git filter-branch -f --env-filter "$each" -- --all >/dev/null || rc="$?"
-        fi
+        git filter-branch -f --env-filter "$each" -- --all || rc="$?"
     else
-        if [ "${DEBUG}" -eq 1 ];
-        then
-            echo "Chunk $ITERATOR/$COLITER Started"
-            git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}"..HEAD || rc="$?"
-            echo "Chunk $ITERATOR/$COLITER Finished"
-        else
-            git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}..HEAD" >/dev/null || rc="$?"
-        fi
+        git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}"..HEAD || rc="$?"
     fi
+
+    debug "Chunk $ITERATOR/$COLITER Finished"
 
     ITERATOR="$((ITERATOR+1))"
 done

--- a/git-redate
+++ b/git-redate
@@ -113,8 +113,12 @@ croak () {
     die "${dashless}: $*"
 }
 
-tmpfile=$(mktemp gitblah-XXXX)
-[ -f "$tmpfile" ] || croak "could not get tmpfile=[$tmpfile]"
+GIT_DIR="${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}"
+
+if ! tmpfile=$(mktemp "${GIT_DIR:+${GIT_DIR}/}GIT_REDATE.XXXXXXXXXX") || ! [ -f "$tmpfile" ]; then
+    croak "could not get tmpfile=[$tmpfile]"
+fi
+
 trap "rm -f $tmpfile" EXIT
 
 

--- a/git-redate
+++ b/git-redate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 is_git_repo() {
     git rev-parse --show-toplevel > /dev/null 2>&1

--- a/git-redate
+++ b/git-redate
@@ -6,9 +6,14 @@ dashless="${dashless%%-*} ${dashless#*-}"
 # This variable is consulted by the code in "git-sh-setup", which is sourced
 # below -- we don't need to export the variable.
 # shellcheck disable=SC2034
-OPTIONS_SPEC="${dashless} [<options>]
+OPTIONS_SPEC="\
+${dashless} [<options>] [[--] <rev-list-options>]
 
-${dashless} changes the dates of one or more git commits according to an interactively-specified scheme.
+Change the dates of one or more git commits according to an interactively-specified scheme.
+
+${dashless} --all
+${dashless} --count 10
+${dashless} HEAD~10..HEAD~6
 --
 d,debug             show diagnostic output
 c,commits=<commits> number of commits to re-date (default: 5)

--- a/git-redate
+++ b/git-redate
@@ -21,6 +21,8 @@ l,limit=<limit>      number of commits to re-date in a single batch (default: 20
 a,all                re-date all commits
 n,dry-run            show re-dating commands, but do not execute them
 original=<namespace> namespace where original commits will be stored (default: refs/original)
+S,gpg-sign?<keyid>   sign commits (negate with --no-gpg-sign)
+no-gpg-sign*         do not sign commits
 "
 
 # Allow running this command from a subdirectory of the working tree
@@ -64,6 +66,26 @@ while [ "$#" -ge 1 ]; do
     --original)
         ORIGINAL="$2"
         shift
+        ;;
+    -S | --gpg-sign)
+        GPGSIGN=1
+
+        # XXX assumes key IDs do not start with `-` characters
+        if [ "$#" -ge 2 ]; then
+            case "$2" in
+                -*)
+                    # NOP, no key ID
+                    ;;
+                *)
+                    echo KEYID="$2"
+                    KEYID="$2"
+                    shift
+                    ;;
+            esac
+        fi
+        ;;
+    --no-gpg-sign)
+        GPGSIGN=0
         ;;
     --)
         shift
@@ -140,6 +162,7 @@ COMMITS="$(git_config_get_posint_cond redate.commits "${COMMITS:-}" 5)" || exit
 DEBUG="$(git_config_get_bool_cond redate.debug "${DEBUG:-}" 0)" || exit
 LIMITCHUNKS="$(git_config_get_posint_cond redate.limit "${LIMITCHUNKS:-}" 20)" || exit
 ORIGINAL="$(git_config_get_cond redate.original "${ORIGINAL:-}" refs/original)" || exit
+GPGSIGN="$(git_config_get_bool_cond redate.gpgsign "${GPGSIGN:-}" 0)" || exit
 
 croak()  {
     # `die` is from git-sh-setup
@@ -178,6 +201,31 @@ else
     }
 fi
 
+run_filter_branch_base() {
+    run git filter-branch -f --original "$ORIGINAL" "$@"
+}
+
+if [ "${GPGSIGN:-0}" = 1 ]; then
+    if [ -n "${KEYID:-}" ]; then
+        run_filter_branch() {
+            # Prevent shell injection via `KEYID` by exporting it inline and
+            # expanding the exported value safely within the commit filter
+            # command.
+            # shellcheck disable=SC2016
+            __GIT_REDATE_KEYID="$KEYID" run_filter_branch_base --commit-filter 'git commit-tree -S"${__GIT_REDATE_KEYID?}" "$@"' "$@"
+        }
+    else
+        run_filter_branch() {
+            run_filter_branch_base --commit-filter 'git commit-tree -S "$@"' "$@"
+        }
+    fi
+else
+    run_filter_branch() {
+        run_filter_branch_base "$@"
+    }
+fi
+
+
 list_commits() {
     # XXX `--exclude` must come before `--all`, etc.; it only affects
     # *subsequent* commit-filtering options.
@@ -188,7 +236,7 @@ apply_redate() {
     env_filter="${1?}" || return
     shift
 
-    run git filter-branch -f --original "$ORIGINAL" --env-filter "$env_filter" -- "$@"
+    run_filter_branch --env-filter "$env_filter" -- "$@"
 }
 
 datefmt=%cI

--- a/git-redate
+++ b/git-redate
@@ -239,6 +239,10 @@ END
     fi
 done < "$tmpfile"
 
+if [ "$COLITER" -gt 0 ]; then
+    debug "Chunk $COLITER Finished"
+fi
+
 rc=0
 ITERATOR=1
 while [ "$ITERATOR" -le "$COLITER" ]; do

--- a/git-redate
+++ b/git-redate
@@ -21,6 +21,10 @@ n,dry-run           show re-dating commands, but do not execute them
 # shellcheck disable=SC1091
 SUBDIRECTORY_OK=yes . "$(git --exec-path)/git-sh-setup"
 
+diag() {
+    echo "$*" 1>&2
+}
+
 make_editor_choice() {
 
     echo 'Which editor do you want to use for this repo?'
@@ -132,7 +136,7 @@ trap cleanup EXIT
 
 if [ "$DEBUG" = 1 ]; then
     debug() {
-        echo "$*" 1>&2
+        diag "$@"
     }
 else
     debug() {
@@ -142,7 +146,7 @@ fi
 
 if [ "$DRY_RUN" = 1 ]; then
     run() {
-        echo "$*" 1>&2
+        diag "$@"
     }
 else
     run() {
@@ -247,8 +251,8 @@ do
 done
 
 if [ "$rc" = 0 ] ; then
-    echo "Git commit dates updated. Run 'git push -f BRANCH_NAME' to push your changes."
+    diag "Git commit dates updated. Run 'git push -f BRANCH_NAME' to push your changes."
 else
-    echo "Git redate failed. Please make sure you run this on a clean working directory."
+    diag "Git redate failed. Please make sure you run this on a clean working directory."
     exit "$rc"
 fi

--- a/git-redate
+++ b/git-redate
@@ -39,10 +39,10 @@ is_has_editor() {
 	OUR_EDITOR="$EDITOR";
     else
         make_editor_choice;
-        if [ ${CHOOSE_EDITOR} == 3 ] || [ ${CHOOSE_EDITOR} == "3" ]; then
+        if [ ${CHOOSE_EDITOR} = 3 ] || [ ${CHOOSE_EDITOR} = "3" ]; then
             get_editor_executable
             OUR_EDITOR=${EDITOR_PATH}
-        elif [ ${CHOOSE_EDITOR} == 1 ] || [ ${CHOOSE_EDITOR} == "1" ]; then
+        elif [ ${CHOOSE_EDITOR} = 1 ] || [ ${CHOOSE_EDITOR} = "1" ]; then
             OUR_EDITOR="vi";
         else
             OUR_EDITOR="nano";
@@ -58,7 +58,7 @@ ALL=0
 DEBUG=0
 LIMITCHUNKS=20
 
-while [[ $# -ge 1 ]]
+while [ "$#" -ge 1 ]
 do
 key="$1"
 
@@ -99,7 +99,7 @@ trap "rm -f $tmpfile" EXIT
 
 
 datefmt=%cI
-if [ "`git log -n1  --pretty=format:"$datefmt"`" == "$datefmt" ];
+if [ "`git log -n1  --pretty=format:"$datefmt"`" = "$datefmt" ];
 then
     datefmt=%ci
 fi
@@ -119,19 +119,21 @@ ${VISUAL:-${EDITOR:-${OUR_EDITOR}}} $tmpfile
 
 ITER=0
 COLITER=0
-declare -a COLLECTION
 
 COUNTCOMMITS=$(awk 'END {print NR}' $tmpfile)
 
 while read commit || [ -n "$commit" ]; do
 
-    IFS="|" read date hash message <<< "$commit"
-    shopt -s nocasematch
-    if [[ "$date" == 'now' ]]; then
+    IFS="|" read date hash message <<COMMIT
+$commit
+COMMIT
+
+    date_lc="$(echo "$date" | tr '[:upper:]' '[:lower:]')"
+    if [ "$date_lc" = 'now' ]; then
         date=$(date +%Y-%m-%dT%H:%M:%S%z);
     fi
-    shopt -u nocasematch
-    if [ "$datefmt" == "%cI" ]
+
+    if [ "$datefmt" = "%cI" ]
     then
         DATE_NO_SPACE="$(echo "${date}" | tr -d '[[:space:]]')"
     else
@@ -148,58 +150,60 @@ fi;
 END
 )
 
-    ((ITER++))
-
-    if [ "${DEBUG}" -eq 1 ] && [ $((ITER % LIMITCHUNKS)) == $((LIMITCHUNKS - 1)) ];
+    if [ $((ITER % LIMITCHUNKS)) = 0 ]
     then
-        echo "Chunk $COLITER Finished"
-    fi
-
-    if [ $((ITER % LIMITCHUNKS)) == 0 ]
-    then
-        ((COLITER++))
+        COLITER="$((COLITER+1))"
 
         if [ "${DEBUG}" -eq 1 ];
         then
             echo "Chunk $COLITER Started"
         fi
-
     fi
 
-    COLLECTION[$COLITER]=${COLLECTION[COLITER]}"$COMMIT_ENV"
+    ITER="$((ITER + 1))"
+
+    eval "__GIT_REDATE_COLLECTION_${COLITER}=\"\${__GIT_REDATE_COLLECTION_${COLITER}:-}\${COMMIT_ENV}\""
+
     if [ "${DEBUG}" -eq 1 ]
     then
         echo "Commit $ITER/$COUNTCOMMITS Collected"
     fi
 
+    if [ "${DEBUG}" -eq 1 ] && [ $((ITER % LIMITCHUNKS)) = 0 ];
+    then
+        echo "Chunk $COLITER Finished"
+    fi
 done < $tmpfile
 
-ITERATOR=0
-for each in "${COLLECTION[@]}"
+ITERATOR=1
+while [ "$ITERATOR" -le "$COLITER" ]
 do
+    each=""
+    eval "each=\"\$__GIT_REDATE_COLLECTION_${ITERATOR}\""
 
-    ((ITERATOR++))
 
     if [ "${ALL}" -eq 1 ];
     then
         if [ "${DEBUG}" -eq 1 ];
         then
-            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Started"
+            echo "Chunk $ITERATOR/$COLITER Started"
             git filter-branch -f --env-filter "$each" -- --all
-            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Finished"
+            echo "Chunk $ITERATOR/$COLITER Finished"
         else
             git filter-branch -f --env-filter "$each" -- --all >/dev/null
         fi
     else
         if [ "${DEBUG}" -eq 1 ];
         then
-            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Started"
+            echo "Chunk $ITERATOR/$COLITER Started"
             git filter-branch -f --env-filter "$each" HEAD~${COMMITS}..HEAD
-            echo "Chunk $ITERATOR/"${#COLLECTION[@]}" Finished"
+            echo "Chunk $ITERATOR/$COLITER Finished"
         else
             git filter-branch -f --env-filter "$each" HEAD~${COMMITS}..HEAD >/dev/null
         fi
     fi
+
+    ITERATOR="$((ITERATOR+1))"
 done
 
 if [ $? = 0 ] ; then

--- a/git-redate
+++ b/git-redate
@@ -60,7 +60,7 @@ while [ "$#" -ge 1 ]; do
         break
         ;;
     *)
-        # unknown option
+        break
         ;;
     esac
     shift
@@ -166,15 +166,16 @@ else
     }
 fi
 
-if [ "$ALL" = 1 ]; then
-    apply_redate() {
-        run git filter-branch -f --env-filter "${1?}" -- --all
-    }
-else
-    apply_redate() {
-        run git filter-branch -f --env-filter "${1?}" "HEAD~${COMMITS}..HEAD"
-    }
-fi
+list_commits() {
+    git rev-list "$@" --no-commit-header --pretty=format:"$datefmt | %H | %s"
+}
+
+apply_redate() {
+    env_filter="${1?}" || return
+    shift
+
+    run git filter-branch -f --env-filter "$env_filter" -- "$@"
+}
 
 datefmt=%cI
 if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ]; then
@@ -182,10 +183,26 @@ if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ]; then
 fi
 
 if [ "$ALL" -eq 1 ]; then
-    git log --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
-else
-    git log -n "$COMMITS" --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
+    set -- --all
+elif [ "$#" -eq 0 ]; then
+    # Don't use `--max-count="$COMMITS"`, as `git filter-branch` passes options
+    # through to both `git rev-list` (which recognizes `--max-count`) *and*
+    # `git rev-parse` (which does not -- or, rather, which treats
+    # `--max-counts="$COUNT"` as a revision to parse).
+    if count="$(list_commits --count HEAD 2>/dev/null)"; then
+        if [ "$count" -lt "$COMMITS" ]; then
+            COMMITS="$count"
+        fi
+    fi
+
+    if [ "$COMMITS" -eq 1 ]; then
+        set -- HEAD
+    else
+        set -- "HEAD~${COMMITS}..HEAD"
+    fi
 fi
+
+list_commits "$@" > "$tmpfile" || exit
 
 git_editor "$tmpfile" || exit
 
@@ -251,7 +268,7 @@ while [ "$ITERATOR" -le "$COLITER" ]; do
 
     debug "Chunk $ITERATOR/$COLITER Started"
 
-    apply_redate "$each" || rc="$?"
+    apply_redate "$each" "$@" || rc="$?"
 
     debug "Chunk $ITERATOR/$COLITER Finished"
 

--- a/git-redate
+++ b/git-redate
@@ -176,12 +176,7 @@ if [ "${ALL}" -eq 1 ];
 then
     git log --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
 else
-    if [ -n "${COMMITS+set}" ]
-    then
-        git log -n "$COMMITS" --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
-    else
-        git log -n 5 --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
-    fi
+    git log -n "$COMMITS" --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
 fi
 
 git_editor "$tmpfile" || exit

--- a/git-redate
+++ b/git-redate
@@ -178,7 +178,7 @@ apply_redate() {
 }
 
 datefmt=%cI
-if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ]; then
+if [ "$(git log -n1 --pretty=format:"$datefmt")" = "$datefmt" ]; then
     datefmt=%ci
 fi
 

--- a/git-redate
+++ b/git-redate
@@ -25,11 +25,6 @@ diag() {
     echo "$@" 1>&2
 }
 
-ALL=0
-DEBUG=0
-DRY_RUN=0
-LIMITCHUNKS=20
-
 while [ "$#" -ge 1 ]
 do
 key="$1"
@@ -37,12 +32,10 @@ key="$1"
 case $key in
     -c| --commits)
     COMMITS="$2"
-    if [ -z "${COMMITS}" ]; then COMMITS="5"; fi;
     shift
     ;;
     -l| --limit)
     LIMITCHUNKS="$2"
-    if [ -z "${LIMITCHUNKS}" ]; then LIMITCHUNKS="20"; fi;
     shift
     ;;
     -d| --debug)
@@ -73,6 +66,68 @@ case $key in
 esac
 shift
 done
+
+git_config_get_cond() {
+    setting="${1?}"
+    shift
+
+    current="${1:-}"
+    shift
+
+    default="${1?}"
+    shift
+
+    if [ -n "${current:-}" ]; then
+        final="$current"
+    else
+        from_config="$(git config "$@" --get "${setting?}")" || {
+            case "$?" in
+                128)
+                    return 128
+                    ;;
+            esac
+        }
+
+        if [ -n "$from_config" ]; then
+            final="$from_config"
+        else
+            final="${default?}"
+        fi
+    fi
+
+    printf -- '%s' "$final"
+}
+
+git_config_get_bool_cond() {
+    raw="$(git_config_get_cond "$@" --bool)" || return
+
+    case "$raw" in
+        true)
+            printf -- '1'
+            ;;
+        false)
+            printf -- '0'
+            ;;
+        *)
+            printf -- '%s' "$raw"
+    esac
+}
+
+git_config_get_posint_cond() {
+    raw="$(git_config_get_cond "$@" --type int)" || return
+
+    if [ -z "$raw" ] || [ "$raw" -lt 1 ]; then
+        die "fatal: bad positive integer config value '${raw}' for '${1?}'"
+        return 128
+    fi
+
+    printf -- '%d' "$raw"
+}
+
+ALL="$(git_config_get_bool_cond redate.all "${ALL:-}" 0)" || exit
+COMMITS="$(git_config_get_posint_cond redate.commits "${COMMITS:-}" 5)" || exit
+DEBUG="$(git_config_get_bool_cond redate.debug "${DEBUG:-}" 0)" || exit
+LIMITCHUNKS="$(git_config_get_posint_cond redate.limit "${LIMITCHUNKS:-}" 20)" || exit
 
 croak () {
     # `die` is from git-sh-setup

--- a/git-redate
+++ b/git-redate
@@ -274,6 +274,10 @@ fi
 
 list_commits "$@" > "$tmpfile" || exit
 
+if ! [ -s "$tmpfile" ]; then
+    croak "no matching commits found; nothing to re-date."
+fi
+
 git_editor "$tmpfile" || exit
 
 ITER=0

--- a/git-redate
+++ b/git-redate
@@ -25,46 +25,45 @@ diag() {
     echo "$@" 1>&2
 }
 
-while [ "$#" -ge 1 ]
-do
-key="$1"
+while [ "$#" -ge 1 ]; do
+    key="$1"
 
-case $key in
-    -c| --commits)
-    COMMITS="$2"
-    shift
-    ;;
-    -l| --limit)
-    LIMITCHUNKS="$2"
-    shift
-    ;;
-    -d| --debug)
-    DEBUG=1
-    ;;
+    case $key in
+    -c | --commits)
+        COMMITS="$2"
+        shift
+        ;;
+    -l | --limit)
+        LIMITCHUNKS="$2"
+        shift
+        ;;
+    -d | --debug)
+        DEBUG=1
+        ;;
     --no-debug)
-    DEBUG=0
-    ;;
-    -a| --all)
-    ALL=1
-    ;;
+        DEBUG=0
+        ;;
+    -a | --all)
+        ALL=1
+        ;;
     --no-all)
-    ALL=0
-    ;;
-    -n| --dry-run)
-    DRY_RUN=1
-    ;;
+        ALL=0
+        ;;
+    -n | --dry-run)
+        DRY_RUN=1
+        ;;
     --no-dry-run)
-    DRY_RUN=0
-    ;;
+        DRY_RUN=0
+        ;;
     --)
-    shift
-    break
-    ;;
+        shift
+        break
+        ;;
     *)
-    # unknown option
-    ;;
-esac
-shift
+        # unknown option
+        ;;
+    esac
+    shift
 done
 
 git_config_get_cond() {
@@ -110,6 +109,7 @@ git_config_get_bool_cond() {
             ;;
         *)
             printf -- '%s' "$raw"
+        ;;
     esac
 }
 
@@ -129,12 +129,12 @@ COMMITS="$(git_config_get_posint_cond redate.commits "${COMMITS:-}" 5)" || exit
 DEBUG="$(git_config_get_bool_cond redate.debug "${DEBUG:-}" 0)" || exit
 LIMITCHUNKS="$(git_config_get_posint_cond redate.limit "${LIMITCHUNKS:-}" 20)" || exit
 
-croak () {
+croak()  {
     # `die` is from git-sh-setup
     die "${dashless}: $*"
 }
 
-GIT_DIR="${GIT_DIR:-$(git rev-parse --git-dir 2>/dev/null)}"
+GIT_DIR="${GIT_DIR:-$(git rev-parse --git-dir 2> /dev/null)}"
 
 if ! tmpfile=$(mktemp "${GIT_DIR:+${GIT_DIR}/}GIT_REDATE.XXXXXXXXXX") || ! [ -f "$tmpfile" ]; then
     croak "could not get tmpfile=[$tmpfile]"
@@ -177,13 +177,11 @@ else
 fi
 
 datefmt=%cI
-if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ];
-then
+if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ]; then
     datefmt=%ci
 fi
 
-if [ "${ALL}" -eq 1 ];
-then
+if [ "$ALL" -eq 1 ]; then
     git log --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
 else
     git log -n "$COMMITS" --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
@@ -197,39 +195,36 @@ COLITER=0
 COUNTCOMMITS=$(awk 'END {print NR}' "$tmpfile")
 
 while read -r commit || [ -n "$commit" ]; do
-
-    IFS="|" read -r date hash _ <<COMMIT
+    IFS="|" read -r date hash _ << COMMIT
 $commit
 COMMIT
 
     date_lc="$(echo "$date" | tr '[:upper:]' '[:lower:]')"
     if [ "$date_lc" = 'now' ]; then
-        date=$(date +%Y-%m-%dT%H:%M:%S%z);
+        date=$(date +%Y-%m-%dT%H:%M:%S%z)
     fi
 
-    if [ "$datefmt" = "%cI" ]
-    then
+    if [ "$datefmt" = "%cI" ]; then
         DATE_NO_SPACE="$(echo "${date}" | tr -d '[:space:]')"
     else
         DATE_NO_SPACE="$date"
     fi
 
-
     # `COMMIT_ENV` is used in an `eval` below; silence warning about unused
     # variable.
     # shellcheck disable=SC2034
-    COMMIT_ENV=$(cat <<-END
+    COMMIT_ENV=$(
+                 cat <<- END
 if [ \$GIT_COMMIT = $hash ];
 then
     export GIT_AUTHOR_DATE="$DATE_NO_SPACE"
     export GIT_COMMITTER_DATE="$DATE_NO_SPACE";
 fi;
 END
-)
+    )
 
-    if [ $((ITER % LIMITCHUNKS)) = 0 ]
-    then
-        COLITER="$((COLITER+1))"
+    if [ $((ITER % LIMITCHUNKS)) = 0 ]; then
+        COLITER="$((COLITER + 1))"
         debug "Chunk $COLITER Started"
     fi
 
@@ -239,16 +234,14 @@ END
 
     debug "Commit $ITER/$COUNTCOMMITS Collected"
 
-    if [ $((ITER % LIMITCHUNKS)) = 0 ];
-    then
+    if [ $((ITER % LIMITCHUNKS)) = 0 ]; then
         debug "Chunk $COLITER Finished"
     fi
 done < "$tmpfile"
 
 rc=0
 ITERATOR=1
-while [ "$ITERATOR" -le "$COLITER" ]
-do
+while [ "$ITERATOR" -le "$COLITER" ]; do
     each=""
     eval "each=\"\$__GIT_REDATE_COLLECTION_${ITERATOR}\""
 
@@ -258,10 +251,10 @@ do
 
     debug "Chunk $ITERATOR/$COLITER Finished"
 
-    ITERATOR="$((ITERATOR+1))"
+    ITERATOR="$((ITERATOR + 1))"
 done
 
-if [ "$rc" = 0 ] ; then
+if [ "$rc" = 0 ]; then
     diag "Git commit dates updated. Run 'git push -f BRANCH_NAME' to push your changes."
 else
     diag "Git redate failed. Please make sure you run this on a clean working directory."

--- a/git-redate
+++ b/git-redate
@@ -22,51 +22,8 @@ n,dry-run           show re-dating commands, but do not execute them
 SUBDIRECTORY_OK=yes . "$(git --exec-path)/git-sh-setup"
 
 diag() {
-    echo "$*" 1>&2
+    echo "$@" 1>&2
 }
-
-make_editor_choice() {
-
-    echo 'Which editor do you want to use for this repo?'
-    echo '1. VI'
-    echo '2. NANO'
-    echo '3. Your own'
-    echo 'You Choose: '
-
-    read -r CHOOSE_EDITOR
-}
-
-get_editor_executable() {
-
-    echo 'What is the path to your prefered test editor?'
-    read -r EDITOR_PATH
-}
-
-
-is_has_editor() {
-    SETTINGS_FILE=~/.redate-settings
-    if [ -f "$SETTINGS_FILE" ]
-    then
-        OUR_EDITOR=$(cat ${SETTINGS_FILE});
-    elif [ -n "${EDITOR:-}" ]
-    then
-	OUR_EDITOR="$EDITOR";
-    else
-        make_editor_choice
-        if [ "$CHOOSE_EDITOR" = 3 ]; then
-            get_editor_executable
-            OUR_EDITOR=${EDITOR_PATH}
-        elif [ "$CHOOSE_EDITOR" = 1 ]; then
-            OUR_EDITOR="vi";
-        else
-            OUR_EDITOR="nano";
-        fi
-        echo "$OUR_EDITOR" > "$SETTINGS_FILE"
-    fi
-}
-
-is_has_editor
-
 
 ALL=0
 DEBUG=0
@@ -172,8 +129,7 @@ else
     fi
 fi
 
-${VISUAL:-${EDITOR:-${OUR_EDITOR}}} "$tmpfile"
-
+git_editor "$tmpfile" || exit
 
 ITER=0
 COLITER=0

--- a/git-redate
+++ b/git-redate
@@ -85,14 +85,12 @@ case $key in
     ;;
     -d| --debug)
     DEBUG=1
-    shift
     ;;
     --no-debug)
     DEBUG=0
     ;;
     -a| --all)
     ALL=1
-    shift
     ;;
     --no-all)
     ALL=0

--- a/git-redate
+++ b/git-redate
@@ -23,41 +23,41 @@ SUBDIRECTORY_OK=yes . "$(git --exec-path)/git-sh-setup"
 
 make_editor_choice() {
 
-    echo "Which editor do you want to use for this repo?\n";
-    echo "1. VI\n";
-    echo "2. NANO\n";
-    echo "3. Your own\n"
-    echo "You Choose: ";
+    echo 'Which editor do you want to use for this repo?'
+    echo '1. VI'
+    echo '2. NANO'
+    echo '3. Your own'
+    echo 'You Choose: '
 
-    read CHOOSE_EDITOR
+    read -r CHOOSE_EDITOR
 }
 
 get_editor_executable() {
 
-    echo "What is the path to your prefered test editor?\n";
-    read EDITOR_PATH
+    echo 'What is the path to your prefered test editor?'
+    read -r EDITOR_PATH
 }
 
 
 is_has_editor() {
-    SETTINGS_FILE="~/.redate-settings";
+    SETTINGS_FILE=~/.redate-settings
     if [ -f "$SETTINGS_FILE" ]
     then
         OUR_EDITOR=$(cat ${SETTINGS_FILE});
-    elif [ ! -z "$EDITOR" ]
+    elif [ -n "${EDITOR:-}" ]
     then
 	OUR_EDITOR="$EDITOR";
     else
-        make_editor_choice;
-        if [ ${CHOOSE_EDITOR} = 3 ] || [ ${CHOOSE_EDITOR} = "3" ]; then
+        make_editor_choice
+        if [ "$CHOOSE_EDITOR" = 3 ]; then
             get_editor_executable
             OUR_EDITOR=${EDITOR_PATH}
-        elif [ ${CHOOSE_EDITOR} = 1 ] || [ ${CHOOSE_EDITOR} = "1" ]; then
+        elif [ "$CHOOSE_EDITOR" = 1 ]; then
             OUR_EDITOR="vi";
         else
             OUR_EDITOR="nano";
         fi
-        echo ${OUR_EDITOR} > ${SETTINGS_FILE}
+        echo "$OUR_EDITOR" > "$SETTINGS_FILE"
     fi
 }
 
@@ -119,36 +119,42 @@ if ! tmpfile=$(mktemp "${GIT_DIR:+${GIT_DIR}/}GIT_REDATE.XXXXXXXXXX") || ! [ -f 
     croak "could not get tmpfile=[$tmpfile]"
 fi
 
-trap "rm -f $tmpfile" EXIT
+cleanup() {
+    rm -f "${tmpfile?}"
+}
+
+trap cleanup EXIT
 
 
 datefmt=%cI
-if [ "`git log -n1  --pretty=format:"$datefmt"`" = "$datefmt" ];
+if [ "$(git log -n1  --pretty=format:"$datefmt")" = "$datefmt" ];
 then
     datefmt=%ci
 fi
 
 if [ "${ALL}" -eq 1 ];
 then
-    git log --pretty=format:"$datefmt | %H | %s" > $tmpfile;
+    git log --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
 else
-    if [ -n "${COMMITS+set}" ];
-    then git log -n ${COMMITS} --pretty=format:"$datefmt | %H | %s" > $tmpfile;
-    else git log -n 5 --pretty=format:"$datefmt | %H | %s" > $tmpfile;
+    if [ -n "${COMMITS+set}" ]
+    then
+        git log -n "$COMMITS" --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
+    else
+        git log -n 5 --pretty=format:"$datefmt | %H | %s" > "$tmpfile"
     fi
 fi
 
-${VISUAL:-${EDITOR:-${OUR_EDITOR}}} $tmpfile
+${VISUAL:-${EDITOR:-${OUR_EDITOR}}} "$tmpfile"
 
 
 ITER=0
 COLITER=0
 
-COUNTCOMMITS=$(awk 'END {print NR}' $tmpfile)
+COUNTCOMMITS=$(awk 'END {print NR}' "$tmpfile")
 
-while read commit || [ -n "$commit" ]; do
+while read -r commit || [ -n "$commit" ]; do
 
-    IFS="|" read date hash message <<COMMIT
+    IFS="|" read -r date hash _ <<COMMIT
 $commit
 COMMIT
 
@@ -159,12 +165,15 @@ COMMIT
 
     if [ "$datefmt" = "%cI" ]
     then
-        DATE_NO_SPACE="$(echo "${date}" | tr -d '[[:space:]]')"
+        DATE_NO_SPACE="$(echo "${date}" | tr -d '[:space:]')"
     else
-        DATE_NO_SPACE="$(echo "${date}")"
+        DATE_NO_SPACE="$date"
     fi
 
 
+    # `COMMIT_ENV` is used in an `eval` below; silence warning about unused
+    # variable.
+    # shellcheck disable=SC2034
     COMMIT_ENV=$(cat <<-END
 if [ \$GIT_COMMIT = $hash ];
 then
@@ -197,41 +206,42 @@ END
     then
         echo "Chunk $COLITER Finished"
     fi
-done < $tmpfile
+done < "$tmpfile"
 
+rc=0
 ITERATOR=1
 while [ "$ITERATOR" -le "$COLITER" ]
 do
     each=""
     eval "each=\"\$__GIT_REDATE_COLLECTION_${ITERATOR}\""
 
-
     if [ "${ALL}" -eq 1 ];
     then
         if [ "${DEBUG}" -eq 1 ];
         then
             echo "Chunk $ITERATOR/$COLITER Started"
-            git filter-branch -f --env-filter "$each" -- --all
+            git filter-branch -f --env-filter "$each" -- --all || rc="$?"
             echo "Chunk $ITERATOR/$COLITER Finished"
         else
-            git filter-branch -f --env-filter "$each" -- --all >/dev/null
+            git filter-branch -f --env-filter "$each" -- --all >/dev/null || rc="$?"
         fi
     else
         if [ "${DEBUG}" -eq 1 ];
         then
             echo "Chunk $ITERATOR/$COLITER Started"
-            git filter-branch -f --env-filter "$each" HEAD~${COMMITS}..HEAD
+            git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}"..HEAD || rc="$?"
             echo "Chunk $ITERATOR/$COLITER Finished"
         else
-            git filter-branch -f --env-filter "$each" HEAD~${COMMITS}..HEAD >/dev/null
+            git filter-branch -f --env-filter "$each" "HEAD~${COMMITS}..HEAD" >/dev/null || rc="$?"
         fi
     fi
 
     ITERATOR="$((ITERATOR+1))"
 done
 
-if [ $? = 0 ] ; then
+if [ "$rc" = 0 ] ; then
     echo "Git commit dates updated. Run 'git push -f BRANCH_NAME' to push your changes."
 else
     echo "Git redate failed. Please make sure you run this on a clean working directory."
+    exit "$rc"
 fi

--- a/git-redate
+++ b/git-redate
@@ -15,11 +15,12 @@ ${dashless} --all
 ${dashless} --count 10
 ${dashless} HEAD~10..HEAD~6
 --
-d,debug             show diagnostic output
-c,commits=<commits> number of commits to re-date (default: 5)
-l,limit=<limit>     number of commits to re-date in a single batch (default: 20)
-a,all               re-date all commits
-n,dry-run           show re-dating commands, but do not execute them
+d,debug              show diagnostic output
+c,commits=<commits>  number of commits to re-date (default: 5)
+l,limit=<limit>      number of commits to re-date in a single batch (default: 20)
+a,all                re-date all commits
+n,dry-run            show re-dating commands, but do not execute them
+original=<namespace> namespace where original commits will be stored (default: refs/original)
 "
 
 # Allow running this command from a subdirectory of the working tree
@@ -60,6 +61,10 @@ while [ "$#" -ge 1 ]; do
     --no-dry-run)
         DRY_RUN=0
         ;;
+    --original)
+        ORIGINAL="$2"
+        shift
+        ;;
     --)
         shift
         break
@@ -68,6 +73,7 @@ while [ "$#" -ge 1 ]; do
         break
         ;;
     esac
+
     shift
 done
 
@@ -133,6 +139,7 @@ ALL="$(git_config_get_bool_cond redate.all "${ALL:-}" 0)" || exit
 COMMITS="$(git_config_get_posint_cond redate.commits "${COMMITS:-}" 5)" || exit
 DEBUG="$(git_config_get_bool_cond redate.debug "${DEBUG:-}" 0)" || exit
 LIMITCHUNKS="$(git_config_get_posint_cond redate.limit "${LIMITCHUNKS:-}" 20)" || exit
+ORIGINAL="$(git_config_get_cond redate.original "${ORIGINAL:-}" refs/original)" || exit
 
 croak()  {
     # `die` is from git-sh-setup
@@ -172,14 +179,16 @@ else
 fi
 
 list_commits() {
-    git rev-list "$@" --no-commit-header --pretty=format:"$datefmt | %H | %s"
+    # XXX `--exclude` must come before `--all`, etc.; it only affects
+    # *subsequent* commit-filtering options.
+    git rev-list --exclude "${ORIGINAL}/*" "$@" --no-commit-header --pretty=format:"$datefmt | %H | %s"
 }
 
 apply_redate() {
     env_filter="${1?}" || return
     shift
 
-    run git filter-branch -f --env-filter "$env_filter" -- "$@"
+    run git filter-branch -f --original "$ORIGINAL" --env-filter "$env_filter" -- "$@"
 }
 
 datefmt=%cI

--- a/git-redate
+++ b/git-redate
@@ -1,15 +1,25 @@
 #!/bin/sh
 
-is_git_repo() {
-    git rev-parse --show-toplevel > /dev/null 2>&1
-    result=$?
-    if test $result != 0; then
-        >&2 echo 'Not a git repo!'
-        exit $result
-  fi
-}
+dashless="${0##*/}"
+dashless="${dashless%%-*} ${dashless#*-}"
 
-is_git_repo
+# This variable is consulted by the code in "git-sh-setup", which is sourced
+# below -- we don't need to export the variable.
+# shellcheck disable=SC2034
+OPTIONS_SPEC="${dashless} [<options>]
+
+${dashless} changes the dates of one or more git commits according to an interactively-specified scheme.
+--
+d,debug             show diagnostic output
+c,commits=<commits> number of commits to re-date (default: 5)
+l,limit=<limit>     number of commits to re-date in a single batch (default: 20)
+a,all               re-date all commits
+"
+
+# Allow running this command from a subdirectory of the working tree
+# shellcheck disable=SC1091
+SUBDIRECTORY_OK=yes . "$(git --exec-path)/git-sh-setup"
+
 
 make_editor_choice() {
 
@@ -77,9 +87,19 @@ case $key in
     DEBUG=1
     shift
     ;;
+    --no-debug)
+    DEBUG=0
+    ;;
     -a| --all)
     ALL=1
     shift
+    ;;
+    --no-all)
+    ALL=0
+    ;;
+    --)
+    shift
+    break
     ;;
     *)
     # unknown option
@@ -88,13 +108,13 @@ esac
 shift
 done
 
-die () {
-    echo >&2 `basename $0`: $*
-    exit 1
+croak () {
+    # `die` is from git-sh-setup
+    die "${dashless}: $*"
 }
 
 tmpfile=$(mktemp gitblah-XXXX)
-[ -f "$tmpfile" ] || die "could not get tmpfile=[$tmpfile]"
+[ -f "$tmpfile" ] || croak "could not get tmpfile=[$tmpfile]"
 trap "rm -f $tmpfile" EXIT
 
 

--- a/git-redate
+++ b/git-redate
@@ -123,7 +123,15 @@ git_config_get_cond() {
         if [ -n "$from_config" ]; then
             final="$from_config"
         else
-            final="${default?}"
+            # Normalize the default value by sending it through the `git
+            # config` machinery.
+            final="$(git -c "${setting?}=${default?}" config "$@" --get "${setting?}")" || {
+                case "$?" in
+                    128)
+                        return 128
+                        ;;
+                esac
+            }
         fi
     fi
 


### PR DESCRIPTION
Thank you for this handy tool!

This PR introduces integration with `git-sh-setup`, a library included with the
core Git distribution.  It provides conveniences for authoring shell-based Git
subcommands.

Summary of features:

1. Added help text (`git redate -h`).
2. Added CLI options sanitation (`git redate` now bails upon unrecognized options).
3. Updated to use `$GIT_EDITOR` / `git var GIT_EDITOR` for editing the re-dating specification file.  This is a breaking change, though one that's likely to align `git redate` with the user's already-expressed preference (e.g. whatever they've defined as `core.editor`) rather than prompting them to express a preference interactively.
4. Added support for specifying `git redate` preferences in the Git client configuration file.
5. Added support for specifying arbitrary commit ranges.

Miscellaneous other changes:

1. Streamlined some code (e.g. removing repeated checks of the value of `$ALL`, `$DEBUG`, etc., instead using conditionally-defined functions).
2. Prevent trying to `shift` any arguments when `$@` is already empty.
3. Added a dry-run mode, which was helpful for testing the other changes and perhaps useful for end users before re-dating For Real.
4. Fixed some `shellcheck` linting issues.
5. Formatted the code with `shfmt`.
6. Relocated the temporary file used for specifying date edits to the `.git` directory.

Thanks for your consideration!